### PR TITLE
Follow rustc 0.11-pre (a990920 2014-05-08)

### DIFF
--- a/src/mustache/builder.rs
+++ b/src/mustache/builder.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use collections::HashMap;
 use serialize::Encodable;
 
@@ -23,17 +24,17 @@ impl<'a> MapBuilder<'a> {
     ///
     /// ```rust
     /// let data = MapBuilder::new()
-    ///     .insert(~"name", & &"Jane Austen").unwrap()
-    ///     .insert(~"age", &41).unwrap()
+    ///     .insert("name", &("Jane Austen")).unwrap()
+    ///     .insert("age", &41).unwrap()
     ///     .build();
     /// ```
     #[inline]
     pub fn insert<
-        T: Encodable<Encoder<'a>, Error>
-    >(self, key: ~str, value: &T) -> Result<MapBuilder<'a>, Error> {
+        K: StrAllocating, T: Encodable<Encoder<'a>, Error>
+    >(self, key: K, value: &T) -> Result<MapBuilder<'a>, Error> {
         let MapBuilder { mut data } = self;
         let value = try!(encoder::encode(value));
-        data.insert(key, value);
+        data.insert(key.into_owned(), value);
         Ok(MapBuilder { data: data })
     }
 
@@ -41,13 +42,15 @@ impl<'a> MapBuilder<'a> {
     ///
     /// ```rust
     /// let data = MapBuilder::new()
-    ///     .insert_str(~"name", ~"Jane Austen")
+    ///     .insert_str("name", "Jane Austen")
     ///     .build();
     /// ```
     #[inline]
-    pub fn insert_str(self, key: ~str, value: ~str) -> MapBuilder<'a> {
+    pub fn insert_str<
+        K: StrAllocating, V: StrAllocating
+    >(self, key: K, value: V) -> MapBuilder<'a> {
         let MapBuilder { mut data } = self;
-        data.insert(key, Str(value));
+        data.insert(key.into_owned(), Str(value.into_owned()));
         MapBuilder { data: data }
     }
 
@@ -55,13 +58,13 @@ impl<'a> MapBuilder<'a> {
     ///
     /// ```rust
     /// let data = MapBuilder::new()
-    ///     .insert_bool(~"show", true)
+    ///     .insert_bool("show", true)
     ///     .build();
     /// ```
     #[inline]
-    pub fn insert_bool(self, key: ~str, value: bool) -> MapBuilder<'a> {
+    pub fn insert_bool<K: StrAllocating>(self, key: K, value: bool) -> MapBuilder<'a> {
         let MapBuilder { mut data } = self;
-        data.insert(key, Bool(value));
+        data.insert(key.into_owned(), Bool(value));
         MapBuilder { data: data }
     }
 
@@ -69,18 +72,18 @@ impl<'a> MapBuilder<'a> {
     ///
     /// ```rust
     /// let data = MapBuilder::new()
-    ///     .insert_vec(~"authors", |builder| {
+    ///     .insert_vec("authors", |builder| {
     ///         builder
-    ///             .push_str(~"Jane Austen")
-    ///             .push_str(~"Lewis Carroll")
+    ///             .push_str("Jane Austen")
+    ///             .push_str("Lewis Carroll")
     ///     })
     ///     .build();
     /// ```
     #[inline]
-    pub fn insert_vec(self, key: ~str, f: |VecBuilder<'a>| -> VecBuilder<'a>) -> MapBuilder<'a> {
+    pub fn insert_vec<K: StrAllocating>(self, key: K, f: |VecBuilder<'a>| -> VecBuilder<'a>) -> MapBuilder<'a> {
         let MapBuilder { mut data } = self;
         let builder = f(VecBuilder::new());
-        data.insert(key, builder.build());
+        data.insert(key.into_owned(), builder.build());
         MapBuilder { data: data }
     }
 
@@ -88,23 +91,23 @@ impl<'a> MapBuilder<'a> {
     ///
     /// ```rust
     /// let data = MapBuilder::new()
-    ///     .insert_map(~"person1", |builder| {
+    ///     .insert_map("person1", |builder| {
     ///         builder
-    ///             .insert_str(~"first_name", ~"Jane")
-    ///             .insert_str(~"last_name", ~"Austen")
+    ///             .insert_str("first_name", "Jane")
+    ///             .insert_str("last_name", "Austen")
     ///     })
-    ///     .insert_map(~"person2", |builder| {
+    ///     .insert_map("person2", |builder| {
     ///         builder
-    ///             .insert_str(~"first_name", ~"Lewis")
-    ///             .insert_str(~"last_name", ~"Carroll")
+    ///             .insert_str("first_name", "Lewis")
+    ///             .insert_str("last_name", "Carroll")
     ///     })
     ///     .build();
     /// ```
     #[inline]
-    pub fn insert_map(self, key: ~str, f: |MapBuilder<'a>| -> MapBuilder<'a>) -> MapBuilder<'a> {
+    pub fn insert_map<K: StrAllocating>(self, key: K, f: |MapBuilder<'a>| -> MapBuilder<'a>) -> MapBuilder<'a> {
         let MapBuilder { mut data } = self;
         let builder = f(MapBuilder::new());
-        data.insert(key, builder.build());
+        data.insert(key.into_owned(), builder.build());
         MapBuilder { data: data }
     }
 
@@ -113,16 +116,16 @@ impl<'a> MapBuilder<'a> {
     /// ```rust
     /// let mut count = 0;
     /// let data = MapBuilder::new()
-    ///     .insert_fn(~"increment", |_| {
+    ///     .insert_fn("increment", |_| {
     ///         count += 1;
     ///         count.to_str()
     ///     })
     ///     .build();
     /// ```
     #[inline]
-    pub fn insert_fn(self, key: ~str, f: |~str|: 'a -> ~str) -> MapBuilder<'a> {
+    pub fn insert_fn<K: StrAllocating>(self, key: K, f: |~str|: 'a -> ~str) -> MapBuilder<'a> {
         let MapBuilder { mut data } = self;
-        data.insert(key, Fun(f));
+        data.insert(key.into_owned(), Fun(RefCell::new(f)));
         MapBuilder { data: data }
     }
 
@@ -168,14 +171,14 @@ impl<'a> VecBuilder<'a> {
     ///
     /// ```rust
     /// let data = VecBuilder::new()
-    ///     .push_str(~"Jane Austen")
-    ///     .push_str(~"Lewis Carroll")
+    ///     .push_str("Jane Austen")
+    ///     .push_str("Lewis Carroll")
     ///     .build();
     /// ```
     #[inline]
-    pub fn push_str(self, value: ~str) -> VecBuilder<'a> {
+    pub fn push_str<T: StrAllocating>(self, value: T) -> VecBuilder<'a> {
         let VecBuilder { mut data } = self;
-        data.push(Str(value));
+        data.push(Str(value.into_owned()));
         VecBuilder { data: data }
     }
 
@@ -251,7 +254,7 @@ impl<'a> VecBuilder<'a> {
     #[inline]
     pub fn push_fn(self, f: |~str|: 'a -> ~str) -> VecBuilder<'a> {
         let VecBuilder { mut data } = self;
-        data.push(Fun(f));
+        data.push(Fun(RefCell::new(f)));
         VecBuilder { data: data }
     }
 
@@ -282,31 +285,31 @@ mod tests {
     #[test]
     fn test_builders() {
         let mut pride_and_prejudice = HashMap::new();
-        pride_and_prejudice.insert(~"title", Str(~"Pride and Prejudice"));
-        pride_and_prejudice.insert(~"publish_date", Str(~"1813"));
+        pride_and_prejudice.insert("title".to_owned(), Str("Pride and Prejudice".to_owned()));
+        pride_and_prejudice.insert("publish_date".to_owned(), Str("1813".to_owned()));
 
         let mut m = HashMap::new();
-        m.insert(~"first_name", Str(~"Jane"));
-        m.insert(~"last_name", Str(~"Austen"));
-        m.insert(~"age", Str(~"41"));
-        m.insert(~"died", Bool(true));
-        m.insert(~"works", Vec(vec!(
-            Str(~"Sense and Sensibility"),
+        m.insert("first_name".to_owned(), Str("Jane".to_owned()));
+        m.insert("last_name".to_owned(), Str("Austen".to_owned()));
+        m.insert("age".to_owned(), Str("41".to_owned()));
+        m.insert("died".to_owned(), Bool(true));
+        m.insert("works".to_owned(), Vec(vec!(
+            Str("Sense and Sensibility".to_owned()),
             Map(pride_and_prejudice))));
 
         assert_eq!(
             MapBuilder::new()
-                .insert_str(~"first_name", ~"Jane")
-                .insert_str(~"last_name", ~"Austen")
-                .insert(~"age", &41).unwrap()
-                .insert_bool(~"died", true)
-                .insert_vec(~"works", |builder| {
+                .insert_str("first_name", "Jane")
+                .insert_str("last_name", "Austen")
+                .insert("age", &41).unwrap()
+                .insert_bool("died", true)
+                .insert_vec("works", |builder| {
                     builder
-                        .push_str(~"Sense and Sensibility")
+                        .push_str("Sense and Sensibility")
                         .push_map(|builder| {
                             builder
-                                .insert_str(~"title", ~"Pride and Prejudice")
-                                .insert(~"publish_date", &1813).unwrap()
+                                .insert_str("title", "Pride and Prejudice")
+                                .insert("publish_date", &1813).unwrap()
                         })
                 })
                 .build(),
@@ -320,7 +323,7 @@ mod tests {
 
         let mut count = 0;
         let data = MapBuilder::new()
-            .insert_fn(~"count", |s| {
+            .insert_fn("count", |s| {
                 count += 1;
                 s + count.to_str()
             })
@@ -328,11 +331,12 @@ mod tests {
 
         match data {
             Map(m) => {
-                match *m.find_equiv(& &"count").unwrap() {
+                match *m.find_equiv(&("count")).unwrap() {
                     Fun(ref f) => {
-                        assert_eq!((*f)(~"count: "), ~"count: 1");
-                        assert_eq!((*f)(~"count: "), ~"count: 2");
-                        assert_eq!((*f)(~"count: "), ~"count: 3");
+                        let f = &mut *f.borrow_mut();
+                        assert_eq!((*f)("count: ".to_owned()), "count: 1".to_owned());
+                        assert_eq!((*f)("count: ".to_owned()), "count: 2".to_owned());
+                        assert_eq!((*f)("count: ".to_owned()), "count: 3".to_owned());
                     }
                     _ => fail!(),
                 }
@@ -358,9 +362,10 @@ mod tests {
             Vec(vs) => {
                 match vs.as_slice() {
                     [Fun(ref f)] => {
-                        assert_eq!((*f)(~"count: "), ~"count: 1");
-                        assert_eq!((*f)(~"count: "), ~"count: 2");
-                        assert_eq!((*f)(~"count: "), ~"count: 3");
+                        let f = &mut *f.borrow_mut();
+                        assert_eq!((*f)("count: ".to_owned()), "count: 1".to_owned());
+                        assert_eq!((*f)("count: ".to_owned()), "count: 2".to_owned());
+                        assert_eq!((*f)("count: ".to_owned()), "count: 3".to_owned());
                     }
                     _ => fail!(),
                 }

--- a/src/mustache/compiler.rs
+++ b/src/mustache/compiler.rs
@@ -21,8 +21,8 @@ impl<T: Iterator<char>> Compiler<T> {
             ctx: ctx,
             reader: reader,
             partials: HashMap::new(),
-            otag: ~"{{",
-            ctag: ~"}}",
+            otag: "{{".into_owned(),
+            ctag: "}}".into_owned(),
         }
     }
 
@@ -69,8 +69,8 @@ impl<T: Iterator<char>> Compiler<T> {
                             ctx: self.ctx.clone(),
                             reader: string.chars(),
                             partials: self.partials.clone(),
-                            otag: ~"{{",
-                            ctag: ~"}}",
+                            otag: "{{".into_owned(),
+                            ctag: "}}".into_owned(),
                         };
 
                         let (tokens, _) = compiler.compile();
@@ -163,62 +163,62 @@ mod tests {
     #[test]
     fn test_compile_texts() {
         check_tokens(compile_str("hello world"), [
-            Text(~"hello world")
+            Text("hello world".to_owned())
         ]);
         check_tokens(compile_str("hello {world"), [
-            Text(~"hello {world")
+            Text("hello {world".to_owned())
         ]);
         check_tokens(compile_str("hello world}"), [
-            Text(~"hello world}")
+            Text("hello world}".to_owned())
         ]);
         check_tokens(compile_str("hello world}}"), [
-            Text(~"hello world}}")
+            Text("hello world}}".to_owned())
         ]);
     }
 
     #[test]
     fn test_compile_etags() {
         check_tokens(compile_str("{{ name }}"), [
-            ETag(vec!(~"name"), ~"{{ name }}")
+            ETag(vec!("name".to_owned()), "{{ name }}".to_owned())
         ]);
 
         check_tokens(compile_str("before {{name}} after"), [
-            Text(~"before "),
-            ETag(vec!(~"name"), ~"{{name}}"),
-            Text(~" after")
+            Text("before ".to_owned()),
+            ETag(vec!("name".to_owned()), "{{name}}".to_owned()),
+            Text(" after".to_owned())
         ]);
 
         check_tokens(compile_str("before {{name}}"), [
-            Text(~"before "),
-            ETag(vec!(~"name"), ~"{{name}}")
+            Text("before ".to_owned()),
+            ETag(vec!("name".to_owned()), "{{name}}".to_owned())
         ]);
 
         check_tokens(compile_str("{{name}} after"), [
-            ETag(vec!(~"name"), ~"{{name}}"),
-            Text(~" after")
+            ETag(vec!("name".to_owned()), "{{name}}".to_owned()),
+            Text(" after".to_owned())
         ]);
     }
 
     #[test]
     fn test_compile_utags() {
         check_tokens(compile_str("{{{name}}}"), [
-            UTag(vec!(~"name"), ~"{{{name}}}")
+            UTag(vec!("name".to_owned()), "{{{name}}}".to_owned())
         ]);
 
         check_tokens(compile_str("before {{{name}}} after"), [
-            Text(~"before "),
-            UTag(vec!(~"name"), ~"{{{name}}}"),
-            Text(~" after")
+            Text("before ".to_owned()),
+            UTag(vec!("name".to_owned()), "{{{name}}}".to_owned()),
+            Text(" after".to_owned())
         ]);
 
         check_tokens(compile_str("before {{{name}}}"), [
-            Text(~"before "),
-            UTag(vec!(~"name"), ~"{{{name}}}")
+            Text("before ".to_owned()),
+            UTag(vec!("name".to_owned()), "{{{name}}}".to_owned())
         ]);
 
         check_tokens(compile_str("{{{name}}} after"), [
-            UTag(vec!(~"name"), ~"{{{name}}}"),
-            Text(~" after")
+            UTag(vec!("name".to_owned()), "{{{name}}}".to_owned()),
+            Text(" after".to_owned())
         ]);
     }
 
@@ -226,119 +226,119 @@ mod tests {
     fn test_compile_sections() {
         check_tokens(compile_str("{{# name}}{{/name}}"), [
             Section(
-                vec!(~"name"),
+                vec!("name".to_owned()),
                 false,
                 Vec::new(),
-                ~"{{",
-                ~"{{# name}}",
-                ~"",
-                ~"{{/name}}",
-                ~"}}"
+                "{{".to_owned(),
+                "{{# name}}".to_owned(),
+                "".to_owned(),
+                "{{/name}}".to_owned(),
+                "}}".to_owned()
             )
         ]);
 
         check_tokens(compile_str("before {{^name}}{{/name}} after"), [
-            Text(~"before "),
+            Text("before ".to_owned()),
             Section(
-                vec!(~"name"),
+                vec!("name".to_owned()),
                 true,
                 Vec::new(),
-                ~"{{",
-                ~"{{^name}}",
-                ~"",
-                ~"{{/name}}",
-                ~"}}"
+                "{{".to_owned(),
+                "{{^name}}".to_owned(),
+                "".to_owned(),
+                "{{/name}}".to_owned(),
+                "}}".to_owned()
             ),
-            Text(~" after")
+            Text(" after".to_owned())
         ]);
 
         check_tokens(compile_str("before {{#name}}{{/name}}"), [
-            Text(~"before "),
+            Text("before ".to_owned()),
             Section(
-                vec!(~"name"),
+                vec!("name".to_owned()),
                 false,
                 Vec::new(),
-                ~"{{",
-                ~"{{#name}}",
-                ~"",
-                ~"{{/name}}",
-                ~"}}"
+                "{{".to_owned(),
+                "{{#name}}".to_owned(),
+                "".to_owned(),
+                "{{/name}}".to_owned(),
+                "}}".to_owned()
             )
         ]);
 
         check_tokens(compile_str("{{#name}}{{/name}} after"), [
             Section(
-                vec!(~"name"),
+                vec!("name".to_owned()),
                 false,
                 Vec::new(),
-                ~"{{",
-                ~"{{#name}}",
-                ~"",
-                ~"{{/name}}",
-                ~"}}"
+                "{{".to_owned(),
+                "{{#name}}".to_owned(),
+                "".to_owned(),
+                "{{/name}}".to_owned(),
+                "}}".to_owned()
             ),
-            Text(~" after")
+            Text(" after".to_owned())
         ]);
 
         check_tokens(compile_str(
                 "before {{#a}} 1 {{^b}} 2 {{/b}} {{/a}} after"), [
-            Text(~"before "),
+            Text("before ".to_owned()),
             Section(
-                vec!(~"a"),
+                vec!("a".to_owned()),
                 false,
                 vec!(
-                    Text(~" 1 "),
+                    Text(" 1 ".to_owned()),
                     Section(
-                        vec!(~"b"),
+                        vec!("b".to_owned()),
                         true,
-                        vec!(Text(~" 2 ")),
-                        ~"{{",
-                        ~"{{^b}}",
-                        ~" 2 ",
-                        ~"{{/b}}",
-                        ~"}}"
+                        vec!(Text(" 2 ".to_owned())),
+                        "{{".to_owned(),
+                        "{{^b}}".to_owned(),
+                        " 2 ".to_owned(),
+                        "{{/b}}".to_owned(),
+                        "}}".to_owned()
                     ),
-                    Text(~" ")
+                    Text(" ".to_owned())
                 ),
-                ~"{{",
-                ~"{{#a}}",
-                ~" 1 {{^b}} 2 {{/b}} ",
-                ~"{{/a}}",
-                ~"}}"
+                "{{".to_owned(),
+                "{{#a}}".to_owned(),
+                " 1 {{^b}} 2 {{/b}} ".to_owned(),
+                "{{/a}}".to_owned(),
+                "}}".to_owned()
             ),
-            Text(~" after")
+            Text(" after".to_owned())
         ]);
     }
 
     #[test]
     fn test_compile_partials() {
         check_tokens(compile_str("{{> test}}"), [
-            Partial(~"test", ~"", ~"{{> test}}")
+            Partial("test".to_owned(), "".to_owned(), "{{> test}}".to_owned())
         ]);
 
         check_tokens(compile_str("before {{>test}} after"), [
-            Text(~"before "),
-            Partial(~"test", ~"", ~"{{>test}}"),
-            Text(~" after")
+            Text("before ".to_owned()),
+            Partial("test".to_owned(), "".to_owned(), "{{>test}}".to_owned()),
+            Text(" after".to_owned())
         ]);
 
         check_tokens(compile_str("before {{> test}}"), [
-            Text(~"before "),
-            Partial(~"test", ~"", ~"{{> test}}")
+            Text("before ".to_owned()),
+            Partial("test".to_owned(), "".to_owned(), "{{> test}}".to_owned())
         ]);
 
         check_tokens(compile_str("{{>test}} after"), [
-            Partial(~"test", ~"", ~"{{>test}}"),
-            Text(~" after")
+            Partial("test".to_owned(), "".to_owned(), "{{>test}}".to_owned()),
+            Text(" after".to_owned())
         ]);
     }
 
     #[test]
     fn test_compile_delimiters() {
         check_tokens(compile_str("before {{=<% %>=}}<%name%> after"), [
-            Text(~"before "),
-            ETag(vec!(~"name"), ~"<%name%>"),
-            Text(~" after")
+            Text("before ".to_owned()),
+            ETag(vec!("name".to_owned()), "<%name%>".to_owned()),
+            Text(" after".to_owned())
         ]);
     }
 }

--- a/src/mustache/lib.rs
+++ b/src/mustache/lib.rs
@@ -12,6 +12,7 @@ extern crate serialize;
 #[phase(syntax, link)]
 extern crate log;
 
+use std::cell::RefCell;
 use std::fmt;
 use std::io::File;
 use std::str;
@@ -34,7 +35,7 @@ pub enum Data<'a> {
     Bool(bool),
     Vec(Vec<Data<'a>>),
     Map(HashMap<~str, Data<'a>>),
-    Fun(|~str|: 'a -> ~str),
+    Fun(RefCell<|~str|: 'a -> ~str>),
 }
 
 impl<'a> Eq for Data<'a> {
@@ -76,7 +77,7 @@ impl Context {
     pub fn new(path: Path) -> Context {
         Context {
             template_path: path,
-            template_extension: ~"mustache",
+            template_extension: "mustache".to_owned(),
         }
     }
 


### PR DESCRIPTION
- Remove all of ~ signs
- Wrap a closure in Data::Fun by RefCell
  - because a mutable reference of closure can be called, while an immutable ref can't.
