### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,8 @@
 # travis and it treats unknown languages as ruby
 language: c
 
-before_install:
-  - sudo apt-get update
 install:
   - curl -s http://www.rust-lang.org/rustup.sh | sudo sh
-  - curl -O http://static.rust-lang.org/cargo-dist/cargo-nightly-linux.tar.gz
-  - tar xf cargo-nightly-linux.tar.gz
 script:
-  - ./cargo-nightly/bin/cargo build --verbose
-  - ./cargo-nightly/bin/cargo test --verbose
+  - /usr/local/bin/cargo build --verbose
+  - /usr/local/bin/cargo test --verbose


### PR DESCRIPTION
Removed unnecessary update of apt-get repositories and download of cargo
(that's already included in rustup.sh). The last travis build failed
because the process ran for too long, so removing this cruft should shorten
it.

Finally, travis-ci doesn't have /usr/local/bin/ in the PATH. So, we use
the absolute path to cargo and screw PATH.

This is build is green on travis as of 7/25/2014 at 9:44pm PST.
