### PR TITLE
Make Template cloneable

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -13,7 +13,7 @@ use encoder::{Encoder, Error};
 use super::{Context, Data, Bool, Str, Vec, Map, Fun};
 
 /// `Template` represents a compiled mustache file.
-#[deriving(Show)]
+#[deriving(Show, Clone)]
 pub struct Template {
     ctx: Context,
     tokens: Vec<Token>,


### PR DESCRIPTION
Is there a reason why it isn't cloneable? It's nice to have when you use the same template in multiple threads.
